### PR TITLE
Support per-branch notification configurations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
         <teamcity-version>9.1.7</teamcity-version>
         <majorVersion>1</majorVersion>
         <minorVersion>4</minorVersion>
-        <patchVersion>7</patchVersion>
+        <patchVersion>8</patchVersion>
         <currentVersion>${majorVersion}.${minorVersion}.${patchVersion}</currentVersion>
     </properties>
     <version>${currentVersion}</version>

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotification.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotification.java
@@ -42,6 +42,8 @@ public interface SlackNotification {
 
     public abstract String getFilterBranchName();
 
+	public abstract String getBranchDisplayName();
+
     public abstract void setFilterBranchName(String branchName);
 
     public abstract String getIconUrl();

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotificationImpl.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotificationImpl.java
@@ -146,22 +146,28 @@ public class SlackNotificationImpl implements SlackNotification {
 		}
     }
 
-    public void post() throws IOException {
-
+    public String getBranchDisplayName() {
         // The actual branch
         String branchDisplayName = this.payload == null ? "" : this.payload.getBranchDisplayName();
 
-        // master branch is not displayed, so we fudge it to be displayed...
-        if (branchDisplayName == null || branchDisplayName.length() == 0) branchDisplayName = "master";
+        // when branchDisplayName is not available, we fudge it to be the magic value <default>.
+        if (branchDisplayName == null || branchDisplayName.length() == 0) {
+            Loggers.SERVER.info("SlackNotificationImpl :: getBranchDisplayName :: branchDisplayName is empty, defaults to <default>.");
+            branchDisplayName = "<default>";
+        }
+        return branchDisplayName;
+    }
 
-        boolean branchNameNotSpecified = this.filterBranchName == null || this.filterBranchName.isEmpty();
-
-        if (branchNameNotSpecified || branchDisplayName.equalsIgnoreCase(this.filterBranchName)) {
+    public void post() throws IOException {
+        if (getFilterBranchName().equalsIgnoreCase(getBranchDisplayName()) ||
+            getFilterBranchName().equalsIgnoreCase("<default>") && this.payload != null && this.payload.getBranchIsDefault()) {
             if (getIsApiToken()) {
                 postViaApi();
             } else {
                 postViaWebHook();
             }
+        } else {
+            Loggers.SERVER.warn("SlackNotificationImpl :: post :: filterBranchName not applicable, posting to Slack skipped.");
         }
     }
 
@@ -629,7 +635,7 @@ public class SlackNotificationImpl implements SlackNotification {
     public void setShowCommits(boolean showCommits) {
         this.showCommits = showCommits;
     }
-	
+
     @Override
     public void setShowCommitters(boolean showCommitters) {
         this.showCommitters = showCommitters;
@@ -640,6 +646,10 @@ public class SlackNotificationImpl implements SlackNotification {
     }
 
     public String getFilterBranchName() {
+        if (this.filterBranchName == null || this.filterBranchName.isEmpty()){
+            setFilterBranchName("<default>");
+            Loggers.SERVER.info("SlackNotification :: filterBranchName is empty, defaults to <default>.");
+        }
         return this.filterBranchName;
     }
 

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/NotificationUtility.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/NotificationUtility.java
@@ -13,7 +13,10 @@ public final class NotificationUtility {
 
     public void doPost(SlackNotification notification){
         try {
-            if (notification.isEnabled()){
+            if (notification.isEnabled() && (
+                    notification.getFilterBranchName().equalsIgnoreCase(notification.getBranchDisplayName()) ||
+                    notification.getFilterBranchName().equalsIgnoreCase("<default>") && notification.getPayload() != null && notification.getPayload().getBranchIsDefault()
+            )) {
                 notification.post();
                 if (notification.getResponse() != null && !notification.getResponse().getOk()) {
                     Loggers.SERVER.error(this.getClass().getSimpleName() + " :: SlackNotification failed : "
@@ -32,11 +35,11 @@ public final class NotificationUtility {
                     Loggers.SERVER.error(notification.getErrorReason());
                 }
                 if ((notification.getStatus() == null || notification.getStatus() > HttpStatus.SC_OK))
-                    Loggers.ACTIVITIES.warn("SlackNotificationListener :: " + notification.getParam("projectId") + " SlackNotification (url: " + notification.getChannel() + " proxy: " + notification.getProxyHost() + ":" + notification.getProxyPort()+") returned HTTP status " + notification.getStatus().toString());
+                    Loggers.ACTIVITIES.warn("SlackNotificationListener :: " + notification.getParam("projectId") + " SlackNotification (url: " + notification.getChannel() + " proxy: " + notification.getProxyHost() + ":" + notification.getProxyPort()+") returned HTTP status " + notification.getStatus());
 
             } else {
-                Loggers.SERVER.debug("SlackNotification NOT triggered: "
-                        + notification.getParam("buildStatus") + " " + notification.getChannel());
+                Loggers.SERVER.info("SlackNotification NOT triggered: "
+                        + notification.getParam("buildStatus") + " " + notification.getChannel() + " isEnabled: " + notification.isEnabled() + " filterBranchName: " + notification.getFilterBranchName() + " branchDisplayName: " + notification.getBranchDisplayName());
             }
         } catch (FileNotFoundException e) {
             Loggers.SERVER.warn(this.getClass().getName() + ":doPost :: "

--- a/tcslackbuildnotifier-core/src/test/java/slacknotifications/teamcity/SlackNotificationListenerTest.java
+++ b/tcslackbuildnotifier-core/src/test/java/slacknotifications/teamcity/SlackNotificationListenerTest.java
@@ -141,7 +141,7 @@ public class SlackNotificationListenerTest {
 	    BuildState buildState = new BuildState();
 	    SlackNotificationMainSettings mainSettings = new SlackNotificationMainSettings(sBuildServer, serverPaths);
 	    mainSettings.readFrom(getFullConfigElement());
-	    SlackNotificationConfig config = new SlackNotificationConfig("", "#general", "teamName", "master", true, buildState, true, true, null, true, true);
+	    SlackNotificationConfig config = new SlackNotificationConfig("", "#general", "teamName", "<default>", true, buildState, true, true, null, true, true);
 	    SlackNotificationListener whl = new SlackNotificationListener(sBuildServer, settings, mainSettings, manager, factory);
 	    
 	    whl.getFromConfig(slackNotificationImpl, config);
@@ -173,7 +173,7 @@ public class SlackNotificationListenerTest {
 	@Test
 	public void testBuildStartedSRunningBuild() throws FileNotFoundException, IOException {
 		BuildState state = new BuildState().setAllEnabled();
-		projSettings.addNewSlackNotification("", "project1", "my-channel", "myteam", "master", true, state, true, true, new HashSet<String>(), true, true);
+		projSettings.addNewSlackNotification("", "project1", "my-channel", "myteam", "", true, state, true, true, new HashSet<String>(), true, true);
 		when(slacknotification.isEnabled()).thenReturn(state.allEnabled());
 		when(buildHistory.getEntriesBefore(sRunningBuild, false)).thenReturn(finishedSuccessfulBuilds);
 		
@@ -184,7 +184,7 @@ public class SlackNotificationListenerTest {
 	@Test
 	public void testBuildFinishedSRunningBuild() throws FileNotFoundException, IOException {
 		BuildState state = new BuildState().setAllEnabled();
-		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", "master", true, state , true, true, new HashSet<String>(), true, true);
+		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", "", true, state , true, true, new HashSet<String>(), true, true);
 		when(slacknotification.isEnabled()).thenReturn(state.allEnabled());
 		when(buildHistory.getEntriesBefore(sRunningBuild, false)).thenReturn(finishedSuccessfulBuilds);
 		
@@ -198,7 +198,7 @@ public class SlackNotificationListenerTest {
 		state.enable(BuildStateEnum.BUILD_FIXED);
 		state.enable(BuildStateEnum.BUILD_FINISHED);
 		state.enable(BuildStateEnum.BUILD_SUCCESSFUL);
-		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", "master", true, state, true, true, new HashSet<String>(), true, true);
+		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", null, true, state, true, true, new HashSet<String>(), true, true);
 		when(slacknotification.isEnabled()).thenReturn(state.enabled(BuildStateEnum.BUILD_FIXED));
 		when(buildHistory.getEntriesBefore(sRunningBuild, false)).thenReturn(finishedFailedBuilds);
 		
@@ -210,7 +210,7 @@ public class SlackNotificationListenerTest {
 	public void testBuildFinishedSRunningBuildSuccessAfterSuccess() throws FileNotFoundException, IOException {
 		BuildState state = new BuildState();
 		state.enable(BuildStateEnum.BUILD_FIXED);
-		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", "master", true, state, true, true, new HashSet<String>(), true, true);
+		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", null, true, state, true, true, new HashSet<String>(), true, true);
 		when(slacknotification.isEnabled()).thenReturn(state.enabled(BuildStateEnum.BUILD_FIXED));
 		when(buildHistory.getEntriesBefore(sRunningBuild, false)).thenReturn(finishedSuccessfulBuilds);
 		
@@ -221,7 +221,7 @@ public class SlackNotificationListenerTest {
 	@Test
 	public void testBuildInterruptedSRunningBuild() throws FileNotFoundException, IOException {
 		BuildState state = new BuildState().setAllEnabled();
-		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", "master", true, state, true, true, new HashSet<String>(), true, true);
+		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", null, true, state, true, true, new HashSet<String>(), true, true);
 		when(buildHistory.getEntriesBefore(sRunningBuild, false)).thenReturn(finishedSuccessfulBuilds);
 		
 		whl.buildInterrupted(sRunningBuild);
@@ -232,7 +232,7 @@ public class SlackNotificationListenerTest {
 	public void testBeforeBuildFinishSRunningBuild() throws FileNotFoundException, IOException {
 		BuildState state = new BuildState();
 		state.enable(BuildStateEnum.BEFORE_BUILD_FINISHED);
-		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", "master", true, state, true, true, new HashSet<String>(), true, true);
+		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", null, true, state, true, true, new HashSet<String>(), true, true);
 		when(buildHistory.getEntriesBefore(sRunningBuild, false)).thenReturn(finishedSuccessfulBuilds);
 		
 		whl.beforeBuildFinish(sRunningBuild);

--- a/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/slackNotificationInclude.jsp
+++ b/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/slackNotificationInclude.jsp
@@ -100,7 +100,7 @@
                                                 </tr>
 												<tr style="border:none">
                                                   <td></td>
-                                                  <td colspan="2"><span class="smallNote" style="margin-left:0px;">Only notify for builds on this branch.</span></td>
+                                                  <td colspan="2"><span class="smallNote" style="margin-left:0px;">Only notify for builds on this branch. Note that if you want to notify on the default branch, use the magic value &lt;default&gt;.</span></td>
                                                 </tr>
 												<tr style="border:none;">
 													<td><label for="slackNotificationsEnabled">Enabled:</label></td>


### PR DESCRIPTION
This change adds the support for multiple per-branch configurations for
a project or a specific build task. For example, users can setup a
config to notify on the staging branch, and another config to notify on
the master (default) branch to a different channel on Slack.

Also, it fixes a potential bug that when the default branch is not
master, branch matching could be incorrect, by falling back to the magic
value `<default>` from TeamCity when `filterBranchName` or
`branchDisplayName` does not exist.