### PR TITLE
Enable slack notifications to only be sent for specified branches

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
         <teamcity-version>9.1.7</teamcity-version>
         <majorVersion>1</majorVersion>
         <minorVersion>4</minorVersion>
-        <patchVersion>6</patchVersion>
+        <patchVersion>7</patchVersion>
         <currentVersion>${majorVersion}.${minorVersion}.${patchVersion}</currentVersion>
     </properties>
     <version>${currentVersion}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
         <teamcity-version>9.1.7</teamcity-version>
         <majorVersion>1</majorVersion>
         <minorVersion>4</minorVersion>
-        <patchVersion>7</patchVersion>
+        <patchVersion>8</patchVersion>
         <currentVersion>${majorVersion}.${minorVersion}.${patchVersion}</currentVersion>
     </properties>
     <version>${currentVersion}</version>

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotification.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotification.java
@@ -28,27 +28,27 @@ public interface SlackNotification {
 
 	public abstract void setChannel(String channel);
 
-    public abstract String getTeamName();
+	public abstract String getTeamName();
 
-    public abstract void setTeamName(String teamName);
+	public abstract void setTeamName(String teamName);
 
-    public abstract String getToken();
+	public abstract String getToken();
 
-    public abstract void setToken(String token);
+	public abstract void setToken(String token);
 
-    public abstract String getBotName();
+	public abstract String getBotName();
 
-    public abstract void setBotName(String botName);
+	public abstract void setBotName(String botName);
 
-    public abstract String getFilterBranchName();
+	public abstract String getFilterBranchName();
 
 	public abstract String getBranchDisplayName();
 
-    public abstract void setFilterBranchName(String branchName);
+	public abstract void setFilterBranchName(String branchName);
 
-    public abstract String getIconUrl();
+	public abstract String getIconUrl();
 
-    public abstract void setIconUrl(String iconUrl);
+	public abstract void setIconUrl(String iconUrl);
 
 	public abstract String getParameterisedUrl();
 
@@ -99,19 +99,19 @@ public interface SlackNotification {
 
 	public abstract void setPayload(SlackNotificationPayloadContent payloadContent);
 
-    public abstract PostMessageResponse getResponse();
+	public abstract PostMessageResponse getResponse();
 
-    public abstract void setShowBuildAgent(Boolean showBuildAgent);
+	public abstract void setShowBuildAgent(Boolean showBuildAgent);
 
-    public abstract void setShowElapsedBuildTime(Boolean showElapsedBuildTime);
-
-    public abstract void setShowCommits(boolean showCommits);
+	public abstract void setShowElapsedBuildTime(Boolean showElapsedBuildTime);
 	
-    public abstract void setShowCommitters(boolean showCommitters);
+	public abstract void setShowCommits(boolean showCommits);
+	
+	public abstract void setShowCommitters(boolean showCommitters);
 
-    public abstract void setMaxCommitsToDisplay(int maxCommitsToDisplay);
+	public abstract void setMaxCommitsToDisplay(int maxCommitsToDisplay);
 
-    public abstract void setMentionChannelEnabled(boolean mentionChannelEnabled);
+	public abstract void setMentionChannelEnabled(boolean mentionChannelEnabled);
 
 	public abstract void setMentionSlackUserEnabled(boolean mentionSlackUserEnabled);
 

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotification.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotification.java
@@ -103,6 +103,8 @@ public interface SlackNotification {
 	
     public abstract void setShowCommitters(boolean showCommitters);
 
+	public abstract void setBranchName(String branchName);
+
     public abstract void setMaxCommitsToDisplay(int maxCommitsToDisplay);
 
     public abstract void setMentionChannelEnabled(boolean mentionChannelEnabled);

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotification.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotification.java
@@ -103,7 +103,7 @@ public interface SlackNotification {
 	
     public abstract void setShowCommitters(boolean showCommitters);
 
-	public abstract void setBranchName(String branchName);
+	public abstract void setFilterBranchName(String filterBranchName);
 
     public abstract void setMaxCommitsToDisplay(int maxCommitsToDisplay);
 

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotification.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotification.java
@@ -40,6 +40,10 @@ public interface SlackNotification {
 
     public abstract void setBotName(String botName);
 
+    public abstract String getFilterBranchName();
+
+    public abstract void setFilterBranchName(String branchName);
+
     public abstract String getIconUrl();
 
     public abstract void setIconUrl(String iconUrl);
@@ -102,8 +106,6 @@ public interface SlackNotification {
     public abstract void setShowCommits(boolean showCommits);
 	
     public abstract void setShowCommitters(boolean showCommitters);
-
-	public abstract void setFilterBranchName(String filterBranchName);
 
     public abstract void setMaxCommitsToDisplay(int maxCommitsToDisplay);
 

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotification.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotification.java
@@ -42,6 +42,8 @@ public interface SlackNotification {
 
     public abstract String getFilterBranchName();
 
+	public abstract String getBranchDisplayName();
+
     public abstract void setFilterBranchName(String branchName);
 
     public abstract String getIconUrl();

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotificationCollection.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotificationCollection.java
@@ -45,6 +45,9 @@ public class SlackNotificationCollection {
             		&& this.canConvertToInt(tokens[SLACKNOTIFICATION_ID])) {
             	// Check if we have already created a slacknotifications instance
             	if (slackNotifications.containsKey(this.convertToInt(tokens[SLACKNOTIFICATION_ID]))){
+            		if ("filterBranchName".equals(tokens[SLACKNOTIFICATION_KEY])) {
+            			slackNotifications.get(this.convertToInt(tokens[SLACKNOTIFICATION_ID])).setFilterBranchName(val);
+					}
             		if ("channel".equals(tokens[SLACKNOTIFICATION_KEY])) {
             			slackNotifications.get(this.convertToInt(tokens[SLACKNOTIFICATION_ID])).setChannel(val);
             		} else if ("teamName".equals(tokens[SLACKNOTIFICATION_KEY])) {

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotificationImpl.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotificationImpl.java
@@ -17,7 +17,6 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.apache.http.HttpHost;
-import org.springframework.util.StringUtils;
 import slacknotifications.teamcity.BuildState;
 import slacknotifications.teamcity.Loggers;
 import slacknotifications.teamcity.payload.content.Commit;
@@ -26,7 +25,6 @@ import slacknotifications.teamcity.payload.content.SlackNotificationPayloadConte
 import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
@@ -67,7 +65,7 @@ public class SlackNotificationImpl implements SlackNotification {
     private Boolean showElapsedBuildTime;
     private boolean showCommits;
     private boolean showCommitters;
-    private String branchName;
+    private String filterBranchName;
     private int maxCommitsToDisplay;
     private boolean mentionChannelEnabled;
     private boolean mentionSlackUserEnabled;
@@ -158,11 +156,9 @@ public class SlackNotificationImpl implements SlackNotification {
         // master branch is not displayed, so we fudge it to be displayed...
         if (branchDisplayName == null || branchDisplayName.length() == 0) branchDisplayName = "master";
 
-        boolean branchNameNotSpecified = this.branchName == null || this.branchName.isEmpty();
+        boolean branchNameNotSpecified = this.filterBranchName == null || this.filterBranchName.isEmpty();
 
-
-
-        if (branchNameNotSpecified || branchDisplayName.equalsIgnoreCase(this.branchName)) {
+        if (branchNameNotSpecified || branchDisplayName.equalsIgnoreCase(this.filterBranchName)) {
             if (getIsApiToken()) {
                 postViaApi();
             } else {
@@ -641,9 +637,8 @@ public class SlackNotificationImpl implements SlackNotification {
         this.showCommitters = showCommitters;
     }
 
-    @Override
-    public void setBranchName(String branchName) {
-        this.branchName = branchName;
+    public void setFilterBranchName(String filterBranchName) {
+        this.filterBranchName = filterBranchName;
     }
 
     @Override

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotificationImpl.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotificationImpl.java
@@ -67,6 +67,7 @@ public class SlackNotificationImpl implements SlackNotification {
     private Boolean showElapsedBuildTime;
     private boolean showCommits;
     private boolean showCommitters;
+    private String branchName;
     private int maxCommitsToDisplay;
     private boolean mentionChannelEnabled;
     private boolean mentionSlackUserEnabled;
@@ -150,13 +151,18 @@ public class SlackNotificationImpl implements SlackNotification {
     }
 
     public void post() throws IOException {
-        if(getIsApiToken()){
-            postViaApi();
-        }
-        else{
-            postViaWebHook();
-        }
 
+        // The actual branch
+        String branchDisplayName = this.payload.getBranchDisplayName();
+
+        boolean branchNameNotSpecified = this.branchName == null || this.branchName.isEmpty();
+        if (branchNameNotSpecified || branchDisplayName.equalsIgnoreCase(this.branchName)) {
+            if (getIsApiToken()) {
+                postViaApi();
+            } else {
+                postViaWebHook();
+            }
+        }
     }
 
     private void postViaApi() throws IOException {
@@ -627,6 +633,11 @@ public class SlackNotificationImpl implements SlackNotification {
     @Override
     public void setShowCommitters(boolean showCommitters) {
         this.showCommitters = showCommitters;
+    }
+
+    @Override
+    public void setBranchName(String branchName) {
+        this.branchName = branchName;
     }
 
     @Override

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotificationImpl.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotificationImpl.java
@@ -155,7 +155,13 @@ public class SlackNotificationImpl implements SlackNotification {
         // The actual branch
         String branchDisplayName = this.payload == null ? "" : this.payload.getBranchDisplayName();
 
+        // master branch is not displayed, so we fudge it to be displayed...
+        if (branchDisplayName == null || branchDisplayName.length() == 0) branchDisplayName = "master";
+
         boolean branchNameNotSpecified = this.branchName == null || this.branchName.isEmpty();
+
+
+
         if (branchNameNotSpecified || branchDisplayName.equalsIgnoreCase(this.branchName)) {
             if (getIsApiToken()) {
                 postViaApi();

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotificationImpl.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotificationImpl.java
@@ -24,8 +24,7 @@ import slacknotifications.teamcity.payload.content.PostMessageResponse;
 import slacknotifications.teamcity.payload.content.SlackNotificationPayloadContent;
 import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
-import java.io.File;
-import java.io.IOException;
+import java.io.*;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -33,7 +32,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-
 
 
 public class SlackNotificationImpl implements SlackNotification {
@@ -150,13 +148,25 @@ public class SlackNotificationImpl implements SlackNotification {
 
     public void post() throws IOException {
 
+        File file = new File("C:/open/stuff.txt");
+        file.createNewFile();
+        DataOutputStream stream = new DataOutputStream(new FileOutputStream(file));
+        //filterBranchName = this.
+        stream.writeUTF("filterBranchName: " + filterBranchName + " \r\n");
+
         // The actual branch
         String branchDisplayName = this.payload == null ? "" : this.payload.getBranchDisplayName();
+        stream.writeUTF("branchDisplayName: " + branchDisplayName + " \r\n");
 
         // master branch is not displayed, so we fudge it to be displayed...
         if (branchDisplayName == null || branchDisplayName.length() == 0) branchDisplayName = "master";
 
+        stream.writeUTF("branchDisplayName after check: " + branchDisplayName + " \r\n");
+
         boolean branchNameNotSpecified = this.filterBranchName == null || this.filterBranchName.isEmpty();
+
+        stream.writeUTF("branchNameNotSpecified: " + branchNameNotSpecified + " \r\n");
+        stream.close();
 
         if (branchNameNotSpecified || branchDisplayName.equalsIgnoreCase(this.filterBranchName)) {
             if (getIsApiToken()) {
@@ -639,6 +649,10 @@ public class SlackNotificationImpl implements SlackNotification {
 
     public void setFilterBranchName(String filterBranchName) {
         this.filterBranchName = filterBranchName;
+    }
+
+    public String getFilterBranchName() {
+        return this.filterBranchName;
     }
 
     @Override

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotificationImpl.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotificationImpl.java
@@ -148,25 +148,13 @@ public class SlackNotificationImpl implements SlackNotification {
 
     public void post() throws IOException {
 
-        File file = new File("C:/open/stuff.txt");
-        file.createNewFile();
-        DataOutputStream stream = new DataOutputStream(new FileOutputStream(file));
-        //filterBranchName = this.
-        stream.writeUTF("filterBranchName: " + filterBranchName + " \r\n");
-
         // The actual branch
         String branchDisplayName = this.payload == null ? "" : this.payload.getBranchDisplayName();
-        stream.writeUTF("branchDisplayName: " + branchDisplayName + " \r\n");
 
         // master branch is not displayed, so we fudge it to be displayed...
         if (branchDisplayName == null || branchDisplayName.length() == 0) branchDisplayName = "master";
 
-        stream.writeUTF("branchDisplayName after check: " + branchDisplayName + " \r\n");
-
         boolean branchNameNotSpecified = this.filterBranchName == null || this.filterBranchName.isEmpty();
-
-        stream.writeUTF("branchNameNotSpecified: " + branchNameNotSpecified + " \r\n");
-        stream.close();
 
         if (branchNameNotSpecified || branchDisplayName.equalsIgnoreCase(this.filterBranchName)) {
             if (getIsApiToken()) {

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotificationImpl.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotificationImpl.java
@@ -146,22 +146,28 @@ public class SlackNotificationImpl implements SlackNotification {
 		}
     }
 
-    public void post() throws IOException {
-
+    public String getBranchDisplayName() {
         // The actual branch
         String branchDisplayName = this.payload == null ? "" : this.payload.getBranchDisplayName();
 
-        // master branch is not displayed, so we fudge it to be displayed...
-        if (branchDisplayName == null || branchDisplayName.length() == 0) branchDisplayName = "master";
+        // when branchDisplayName is not available, we fudge it to be the magic value <default>.
+        if (branchDisplayName == null || branchDisplayName.length() == 0) {
+            Loggers.SERVER.info("SlackNotificationImpl :: getBranchDisplayName :: branchDisplayName is empty, defaults to <default>.");
+            branchDisplayName = "<default>";
+        }
+        return branchDisplayName;
+    }
 
-        boolean branchNameNotSpecified = this.filterBranchName == null || this.filterBranchName.isEmpty();
-
-        if (branchNameNotSpecified || branchDisplayName.equalsIgnoreCase(this.filterBranchName)) {
+    public void post() throws IOException {
+        if (getFilterBranchName().equalsIgnoreCase(getBranchDisplayName()) ||
+            getFilterBranchName().equalsIgnoreCase("<default>") && this.payload != null && this.payload.getBranchIsDefault()) {
             if (getIsApiToken()) {
                 postViaApi();
             } else {
                 postViaWebHook();
             }
+        } else {
+            Loggers.SERVER.warn("SlackNotificationImpl :: post :: filterBranchName not applicable, posting to Slack skipped.");
         }
     }
 
@@ -629,7 +635,7 @@ public class SlackNotificationImpl implements SlackNotification {
     public void setShowCommits(boolean showCommits) {
         this.showCommits = showCommits;
     }
-	
+
     @Override
     public void setShowCommitters(boolean showCommitters) {
         this.showCommitters = showCommitters;
@@ -640,6 +646,10 @@ public class SlackNotificationImpl implements SlackNotification {
     }
 
     public String getFilterBranchName() {
+        if (this.filterBranchName == null || this.filterBranchName.isEmpty()){
+            setFilterBranchName("<default>");
+            Loggers.SERVER.info("SlackNotification :: filterBranchName is empty, defaults to <default>.");
+        }
         return this.filterBranchName;
     }
 

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotificationImpl.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotificationImpl.java
@@ -153,7 +153,7 @@ public class SlackNotificationImpl implements SlackNotification {
     public void post() throws IOException {
 
         // The actual branch
-        String branchDisplayName = this.payload.getBranchDisplayName();
+        String branchDisplayName = this.payload == null ? "" : this.payload.getBranchDisplayName();
 
         boolean branchNameNotSpecified = this.branchName == null || this.branchName.isEmpty();
         if (branchNameNotSpecified || branchDisplayName.equalsIgnoreCase(this.branchName)) {

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/NotificationUtility.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/NotificationUtility.java
@@ -13,7 +13,10 @@ public final class NotificationUtility {
 
     public void doPost(SlackNotification notification){
         try {
-            if (notification.isEnabled()){
+            if (notification.isEnabled() && (
+                    notification.getFilterBranchName().equalsIgnoreCase(notification.getBranchDisplayName()) ||
+                    notification.getFilterBranchName().equalsIgnoreCase("<default>") && notification.getPayload() != null && notification.getPayload().getBranchIsDefault()
+            )) {
                 notification.post();
                 if (notification.getResponse() != null && !notification.getResponse().getOk()) {
                     Loggers.SERVER.error(this.getClass().getSimpleName() + " :: SlackNotification failed : "
@@ -32,11 +35,11 @@ public final class NotificationUtility {
                     Loggers.SERVER.error(notification.getErrorReason());
                 }
                 if ((notification.getStatus() == null || notification.getStatus() > HttpStatus.SC_OK))
-                    Loggers.ACTIVITIES.warn("SlackNotificationListener :: " + notification.getParam("projectId") + " SlackNotification (url: " + notification.getChannel() + " proxy: " + notification.getProxyHost() + ":" + notification.getProxyPort()+") returned HTTP status " + notification.getStatus().toString());
+                    Loggers.ACTIVITIES.warn("SlackNotificationListener :: " + notification.getParam("projectId") + " SlackNotification (url: " + notification.getChannel() + " proxy: " + notification.getProxyHost() + ":" + notification.getProxyPort()+") returned HTTP status " + notification.getStatus());
 
             } else {
-                Loggers.SERVER.debug("SlackNotification NOT triggered: "
-                        + notification.getParam("buildStatus") + " " + notification.getChannel());
+                Loggers.SERVER.info("SlackNotification NOT triggered: "
+                        + notification.getParam("buildStatus") + " " + notification.getChannel() + " isEnabled: " + notification.isEnabled() + " filterBranchName: " + notification.getFilterBranchName() + " branchDisplayName: " + notification.getBranchDisplayName());
             }
         } catch (FileNotFoundException e) {
             Loggers.SERVER.warn(this.getClass().getName() + ":doPost :: "

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/SlackNotificationListener.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/SlackNotificationListener.java
@@ -79,7 +79,7 @@ public class SlackNotificationListener extends BuildServerAdapter {
         slackNotification.setShowElapsedBuildTime(myMainSettings.getShowElapsedBuildTime());
         slackNotification.setShowCommits(myMainSettings.getShowCommits());
         slackNotification.setShowCommitters(myMainSettings.getShowCommitters());
-        slackNotification.setFilterBranchName(myMainSettings.getFilterBranchName());
+        slackNotification.setFilterBranchName(slackNotificationConfig.getFilterBranchName());
         slackNotification.setShowFailureReason(myMainSettings.getShowFailureReason() == null ? SlackNotificationContentConfig.DEFAULT_SHOW_FAILURE_REASON : myMainSettings.getShowFailureReason());
         slackNotification.setMaxCommitsToDisplay(myMainSettings.getMaxCommitsToDisplay());
         slackNotification.setMentionChannelEnabled(slackNotificationConfig.getMentionChannelEnabled());

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/SlackNotificationListener.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/SlackNotificationListener.java
@@ -79,6 +79,7 @@ public class SlackNotificationListener extends BuildServerAdapter {
         slackNotification.setShowElapsedBuildTime(myMainSettings.getShowElapsedBuildTime());
         slackNotification.setShowCommits(myMainSettings.getShowCommits());
         slackNotification.setShowCommitters(myMainSettings.getShowCommitters());
+        slackNotification.setFilterBranchName(myMainSettings.getFilterBranchName());
         slackNotification.setShowFailureReason(myMainSettings.getShowFailureReason() == null ? SlackNotificationContentConfig.DEFAULT_SHOW_FAILURE_REASON : myMainSettings.getShowFailureReason());
         slackNotification.setMaxCommitsToDisplay(myMainSettings.getMaxCommitsToDisplay());
         slackNotification.setMentionChannelEnabled(slackNotificationConfig.getMentionChannelEnabled());

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/SlackNotificator.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/SlackNotificator.java
@@ -214,6 +214,7 @@ public class SlackNotificator implements Notificator {
 
         notification.setTeamName(mainConfig.getTeamName());
         notification.setToken(mainConfig.getToken());
+        notification.setFilterBranchName(mainConfig.getFilterBranchName());
         notification.setIconUrl(mainConfig.getIconUrl());
         notification.setBotName(mainConfig.getBotName());
         notification.setEnabled(mainConfig.getEnabled());

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationConfig.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationConfig.java
@@ -35,6 +35,7 @@ public class SlackNotificationConfig {
 	private static final String SHOW_COMMITTERS = "showCommitters";
 	private static final String MAX_COMMITS_TO_DISPLAY = "maxCommitsToDisplay";
 	private static final String SHOW_FAILURE_REASON = "showFailureReason";
+	private static final String FILTER_BRANCH_NAME = "filterBranchName";
 	
 	
 	private Boolean enabled = true;
@@ -51,8 +52,9 @@ public class SlackNotificationConfig {
 	private boolean mentionSlackUserEnabled;
     private boolean customContent;
     private SlackNotificationContentConfig content;
+	private String filterBranchName;
 
-    @SuppressWarnings("unchecked")
+	@SuppressWarnings("unchecked")
 	public SlackNotificationConfig(Element e) {
 		this.content = new SlackNotificationContentConfig();
 		int Min = 1000000, Max = 1000000000;
@@ -66,6 +68,10 @@ public class SlackNotificationConfig {
 
 		if (e.getAttribute(CHANNEL) != null){
 			this.setChannel(e.getAttributeValue(CHANNEL));
+		}
+
+		if (e.getAttribute(FILTER_BRANCH_NAME) != null){
+			this.setFilterBranchName(e.getAttributeValue(FILTER_BRANCH_NAME));
 		}
 
         if (e.getAttribute(TEAM_NAME) != null){
@@ -181,6 +187,9 @@ public class SlackNotificationConfig {
             if (eContent.getAttribute(SHOW_FAILURE_REASON) != null){
                 this.content.setShowFailureReason(Boolean.parseBoolean(eContent.getAttributeValue(SHOW_FAILURE_REASON)));
             }
+            if (eContent.getAttribute(FILTER_BRANCH_NAME) != null){
+            	setFilterBranchName(eContent.getAttributeValue(FILTER_BRANCH_NAME));
+			}
         }
 
 		
@@ -199,6 +208,7 @@ public class SlackNotificationConfig {
     public SlackNotificationConfig(String token,
 								   String channel,
 								   String teamName,
+								   String filterBranchName,
 								   Boolean enabled,
 								   BuildState states,
 								   boolean buildTypeAllEnabled,
@@ -214,6 +224,7 @@ public class SlackNotificationConfig {
         this.setToken(token);
         this.setChannel(channel);
         this.setTeamName(teamName);
+        this.setFilterBranchName(filterBranchName);
         this.setEnabled(enabled);
         this.setBuildStates(states);
         this.subProjectsEnabled = buildTypeSubProjects;
@@ -228,9 +239,15 @@ public class SlackNotificationConfig {
 	
 	public Element getAsElement(){
 		Element el = new Element("slackNotification");
+
 		el.setAttribute(CHANNEL, this.getChannel());
+
 		if(StringUtil.isNotEmpty(this.getToken())) {
 			el.setAttribute(TOKEN, this.getToken());
+		}
+
+		if(StringUtil.isNotEmpty(this.getFilterBranchName())) {
+			el.setAttribute(FILTER_BRANCH_NAME, this.getFilterBranchName());
 		}
 
         if(StringUtil.isNotEmpty(this.getTeamName())) {
@@ -546,4 +563,8 @@ public class SlackNotificationConfig {
     public void setContent(SlackNotificationContentConfig content) {
         this.content = content;
     }
+
+	public String getFilterBranchName() { return filterBranchName; }
+
+	public void setFilterBranchName(String filterBranchName) { this.filterBranchName = filterBranchName; }
 }

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationContentConfig.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationContentConfig.java
@@ -10,6 +10,7 @@ public class SlackNotificationContentConfig {
     public static final boolean DEFAULT_SHOW_COMMITS = true;
     public static final boolean DEFAULT_SHOW_COMMITTERS = true;
     public static final boolean DEFAULT_SHOW_FAILURE_REASON = false;
+    public static final String DEFAULT_FILTER_BRANCH_NAME = "";
     private String iconUrl = SlackNotificationMainConfig.DEFAULT_ICONURL;
     private String botName = SlackNotificationMainConfig.DEFAULT_BOTNAME;
     private Boolean showBuildAgent;
@@ -19,7 +20,6 @@ public class SlackNotificationContentConfig {
     private int maxCommitsToDisplay = 5;
     private boolean enabled;
     private Boolean showFailureReason;
-    private String filterBranchName;
 
     public String getIconUrl() {
         return iconUrl;
@@ -93,11 +93,4 @@ public class SlackNotificationContentConfig {
         this.enabled = enabled;
     }
 
-    public void setFilterBranchName(String filterBranchName) {
-        this.filterBranchName = filterBranchName;
-    }
-
-    public String getFilterBranchName() {
-        return filterBranchName;
-    }
 }

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationContentConfig.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationContentConfig.java
@@ -19,7 +19,7 @@ public class SlackNotificationContentConfig {
     private int maxCommitsToDisplay = 5;
     private boolean enabled;
     private Boolean showFailureReason;
-    private String branchName;
+    private String filterBranchName;
 
     public String getIconUrl() {
         return iconUrl;
@@ -93,11 +93,11 @@ public class SlackNotificationContentConfig {
         this.enabled = enabled;
     }
 
-    public void setBranchName(String branchName) {
-        this.branchName = branchName;
+    public void setFilterBranchName(String filterBranchName) {
+        this.filterBranchName = filterBranchName;
     }
 
-    public String getBranchName() {
-        return branchName;
+    public String getFilterBranchName() {
+        return filterBranchName;
     }
 }

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationContentConfig.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationContentConfig.java
@@ -19,6 +19,7 @@ public class SlackNotificationContentConfig {
     private int maxCommitsToDisplay = 5;
     private boolean enabled;
     private Boolean showFailureReason;
+    private String branchName;
 
     public String getIconUrl() {
         return iconUrl;
@@ -90,5 +91,13 @@ public class SlackNotificationContentConfig {
 
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;
+    }
+
+    public void setBranchName(String branchName) {
+        this.branchName = branchName;
+    }
+
+    public String getBranchName() {
+        return branchName;
     }
 }

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationMainConfig.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationMainConfig.java
@@ -14,6 +14,7 @@ import slacknotifications.teamcity.Loggers;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
 public class SlackNotificationMainConfig implements ChangeListener {
     public static final String DEFAULT_BOTNAME = "TeamCity";
@@ -35,6 +36,7 @@ public class SlackNotificationMainConfig implements ChangeListener {
 	private static final String PASSWORD = "password";
 	private static final String ENABLED = "enabled";
 	private static final String TEAM_NAME = "teamName";
+	private static final String FILTER_BRANCH_NAME = "filterBranchName";
 
 
     private final FileWatcher myChangeObserver;
@@ -48,6 +50,7 @@ public class SlackNotificationMainConfig implements ChangeListener {
 	private String proxyUsername = null;
 	private String proxyPassword = null;
     private String defaultChannel = null;
+    private String filterBranchName = null;
     private String teamName;
     private String token;
 	private Boolean proxyShortNames = false;
@@ -173,7 +176,15 @@ public class SlackNotificationMainConfig implements ChangeListener {
 		return el;
 	}
 
-    public String getDefaultChannel() {
+	public String getFilterBranchName() {
+		return filterBranchName;
+	}
+
+	public void setFilterBranchName(String filterBranchName) {
+		this.filterBranchName = filterBranchName;
+	}
+
+	public String getDefaultChannel() {
         return defaultChannel;
     }
 
@@ -281,6 +292,7 @@ public class SlackNotificationMainConfig implements ChangeListener {
                         rootElement.setAttribute("enabled", Boolean.toString(SlackNotificationMainConfig.this.enabled));
                         rootElement.setAttribute(TEAM_NAME, emptyIfNull(SlackNotificationMainConfig.this.teamName));
 						rootElement.setAttribute(DEFAULT_CHANNEL, emptyIfNull(SlackNotificationMainConfig.this.defaultChannel));
+						rootElement.setAttribute(FILTER_BRANCH_NAME, emptyIfNull(SlackNotificationMainConfig.this.filterBranchName));
                         rootElement.setAttribute(TEAM_NAME, emptyIfNull(SlackNotificationMainConfig.this.teamName));
 						rootElement.setAttribute(TOKEN, emptyIfNull(SlackNotificationMainConfig.this.token));
 						rootElement.setAttribute(ICON_URL, emptyIfNull(SlackNotificationMainConfig.this.content.getIconUrl()));
@@ -397,6 +409,10 @@ public class SlackNotificationMainConfig implements ChangeListener {
             {
                 content.setShowFailureReason(Boolean.parseBoolean(slackNotificationsElement.getAttributeValue(SHOW_FAILURE_REASON)));
             }
+			if(slackNotificationsElement.getAttribute(FILTER_BRANCH_NAME) != null)
+			{
+				setFilterBranchName(slackNotificationsElement.getAttributeValue(FILTER_BRANCH_NAME));
+			}
 
             Element proxyElement = slackNotificationsElement.getChild(PROXY);
             if(proxyElement != null)

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationMainSettings.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationMainSettings.java
@@ -19,7 +19,6 @@ public class SlackNotificationMainSettings implements MainConfigProcessor {
 	private SBuildServer server;
     private ServerPaths serverPaths;
     private String version;
-    private String includeBranchName;
 
     public SlackNotificationMainSettings(SBuildServer server, ServerPaths serverPaths){
         this.serverPaths = serverPaths;
@@ -128,7 +127,7 @@ public class SlackNotificationMainSettings implements MainConfigProcessor {
     }
 
     public String getFilterBranchName() {
-        return this.slackNotificationMainConfig.getContent().getFilterBranchName();
+        return this.slackNotificationMainConfig.getFilterBranchName();
     }
 
     public Boolean getSlackNotificationShowFurtherReading(){
@@ -159,13 +158,5 @@ public class SlackNotificationMainSettings implements MainConfigProcessor {
         props.load(SlackNotificationMainSettings.class.getResourceAsStream("/version.txt"));
         version = props.getProperty("version");
         return version;
-    }
-
-    public String getBranchName() {
-        return includeBranchName;
-    }
-
-    public void setBranchName(String includeBranchName) {
-        this.includeBranchName = includeBranchName;
     }
 }

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationMainSettings.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationMainSettings.java
@@ -127,6 +127,10 @@ public class SlackNotificationMainSettings implements MainConfigProcessor {
         return this.slackNotificationMainConfig.getContent().getShowFailureReason();
     }
 
+    public String getFilterBranchName() {
+        return this.slackNotificationMainConfig.getContent().getFilterBranchName();
+    }
+
     public Boolean getSlackNotificationShowFurtherReading(){
     	return this.slackNotificationMainConfig.getSlackNotificationShowFurtherReading();
     }

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationMainSettings.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationMainSettings.java
@@ -19,6 +19,7 @@ public class SlackNotificationMainSettings implements MainConfigProcessor {
 	private SBuildServer server;
     private ServerPaths serverPaths;
     private String version;
+    private String includeBranchName;
 
     public SlackNotificationMainSettings(SBuildServer server, ServerPaths serverPaths){
         this.serverPaths = serverPaths;
@@ -154,5 +155,13 @@ public class SlackNotificationMainSettings implements MainConfigProcessor {
         props.load(SlackNotificationMainSettings.class.getResourceAsStream("/version.txt"));
         version = props.getProperty("version");
         return version;
+    }
+
+    public String getBranchName() {
+        return includeBranchName;
+    }
+
+    public void setBranchName(String includeBranchName) {
+        this.includeBranchName = includeBranchName;
     }
 }

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationProjectSettings.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationProjectSettings.java
@@ -132,7 +132,7 @@ public class SlackNotificationProjectSettings implements ProjectSettings {
         }    	
     }
 
-	public void updateSlackNotification(String ProjectId, String token, String slackNotificationId, String channel, Boolean enabled, BuildState buildState, boolean buildTypeAll, boolean buildSubProjects, Set<String> buildTypesEnabled, boolean mentionChannelEnabled, boolean mentionSlackUserEnabled, SlackNotificationContentConfig content) {
+	public void updateSlackNotification(String ProjectId, String token, String slackNotificationId, String channel, String filterBranchName, Boolean enabled, BuildState buildState, boolean buildTypeAll, boolean buildSubProjects, Set<String> buildTypesEnabled, boolean mentionChannelEnabled, boolean mentionSlackUserEnabled, SlackNotificationContentConfig content) {
         if(this.slackNotificationsConfigs != null)
         {
         	updateSuccess = false;
@@ -143,6 +143,7 @@ public class SlackNotificationProjectSettings implements ProjectSettings {
                 	whc.setEnabled(enabled);
 					whc.setToken(token);
                 	whc.setChannel(channel);
+                	whc.setFilterBranchName(filterBranchName);
                     whc.setMentionChannelEnabled(mentionChannelEnabled);
 					whc.setMentionSlackUserEnabled(mentionSlackUserEnabled);
                 	whc.setBuildStates(buildState);
@@ -163,8 +164,8 @@ public class SlackNotificationProjectSettings implements ProjectSettings {
         }    			
 	}
 
-	public void addNewSlackNotification(String ProjectId, String token, String channel, String teamName, Boolean enabled, BuildState buildState, boolean buildTypeAll, boolean buildTypeSubProjects, Set<String> buildTypesEnabled, boolean mentionChannelEnabled, boolean mentionSlackUserEnabled) {
-		this.slackNotificationsConfigs.add(new SlackNotificationConfig(token, channel, teamName, enabled, buildState, buildTypeAll, buildTypeSubProjects, buildTypesEnabled, mentionChannelEnabled, mentionSlackUserEnabled));
+	public void addNewSlackNotification(String ProjectId, String token, String channel, String teamName, String filterBranchName, Boolean enabled, BuildState buildState, boolean buildTypeAll, boolean buildTypeSubProjects, Set<String> buildTypesEnabled, boolean mentionChannelEnabled, boolean mentionSlackUserEnabled) {
+		this.slackNotificationsConfigs.add(new SlackNotificationConfig(token, channel, teamName, filterBranchName, enabled, buildState, buildTypeAll, buildTypeSubProjects, buildTypesEnabled, mentionChannelEnabled, mentionSlackUserEnabled));
 		Loggers.SERVER.debug(NAME + ":addNewSlackNotification :: Adding slack notifications to " + ProjectId + " with channel " + channel);
 		this.updateSuccess = true;
 	}

--- a/tcslackbuildnotifier-core/src/test/java/slacknotifications/teamcity/SlackNotificationListenerTest.java
+++ b/tcslackbuildnotifier-core/src/test/java/slacknotifications/teamcity/SlackNotificationListenerTest.java
@@ -141,7 +141,7 @@ public class SlackNotificationListenerTest {
 	    BuildState buildState = new BuildState();
 	    SlackNotificationMainSettings mainSettings = new SlackNotificationMainSettings(sBuildServer, serverPaths);
 	    mainSettings.readFrom(getFullConfigElement());
-	    SlackNotificationConfig config = new SlackNotificationConfig("", "#general", "teamName", "master", true, buildState, true, true, null, true, true);
+	    SlackNotificationConfig config = new SlackNotificationConfig("", "#general", "teamName", "<default>", true, buildState, true, true, null, true, true);
 	    SlackNotificationListener whl = new SlackNotificationListener(sBuildServer, settings, mainSettings, manager, factory);
 	    
 	    whl.getFromConfig(slackNotificationImpl, config);
@@ -173,7 +173,7 @@ public class SlackNotificationListenerTest {
 	@Test
 	public void testBuildStartedSRunningBuild() throws FileNotFoundException, IOException {
 		BuildState state = new BuildState().setAllEnabled();
-		projSettings.addNewSlackNotification("", "project1", "my-channel", "myteam", "master", true, state, true, true, new HashSet<String>(), true, true);
+		projSettings.addNewSlackNotification("", "project1", "my-channel", "myteam", "", true, state, true, true, new HashSet<String>(), true, true);
 		when(slacknotification.isEnabled()).thenReturn(state.allEnabled());
 		when(buildHistory.getEntriesBefore(sRunningBuild, false)).thenReturn(finishedSuccessfulBuilds);
 		
@@ -184,7 +184,7 @@ public class SlackNotificationListenerTest {
 	@Test
 	public void testBuildFinishedSRunningBuild() throws FileNotFoundException, IOException {
 		BuildState state = new BuildState().setAllEnabled();
-		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", "master", true, state , true, true, new HashSet<String>(), true, true);
+		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", "", true, state , true, true, new HashSet<String>(), true, true);
 		when(slacknotification.isEnabled()).thenReturn(state.allEnabled());
 		when(buildHistory.getEntriesBefore(sRunningBuild, false)).thenReturn(finishedSuccessfulBuilds);
 		
@@ -198,7 +198,7 @@ public class SlackNotificationListenerTest {
 		state.enable(BuildStateEnum.BUILD_FIXED);
 		state.enable(BuildStateEnum.BUILD_FINISHED);
 		state.enable(BuildStateEnum.BUILD_SUCCESSFUL);
-		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", "master", true, state, true, true, new HashSet<String>(), true, true);
+		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", null, true, state, true, true, new HashSet<String>(), true, true);
 		when(slacknotification.isEnabled()).thenReturn(state.enabled(BuildStateEnum.BUILD_FIXED));
 		when(buildHistory.getEntriesBefore(sRunningBuild, false)).thenReturn(finishedFailedBuilds);
 		
@@ -210,7 +210,7 @@ public class SlackNotificationListenerTest {
 	public void testBuildFinishedSRunningBuildSuccessAfterSuccess() throws FileNotFoundException, IOException {
 		BuildState state = new BuildState();
 		state.enable(BuildStateEnum.BUILD_FIXED);
-		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", "master", true, state, true, true, new HashSet<String>(), true, true);
+		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", null, true, state, true, true, new HashSet<String>(), true, true);
 		when(slacknotification.isEnabled()).thenReturn(state.enabled(BuildStateEnum.BUILD_FIXED));
 		when(buildHistory.getEntriesBefore(sRunningBuild, false)).thenReturn(finishedSuccessfulBuilds);
 		
@@ -221,7 +221,7 @@ public class SlackNotificationListenerTest {
 	@Test
 	public void testBuildInterruptedSRunningBuild() throws FileNotFoundException, IOException {
 		BuildState state = new BuildState().setAllEnabled();
-		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", "master", true, state, true, true, new HashSet<String>(), true, true);
+		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", null, true, state, true, true, new HashSet<String>(), true, true);
 		when(buildHistory.getEntriesBefore(sRunningBuild, false)).thenReturn(finishedSuccessfulBuilds);
 		
 		whl.buildInterrupted(sRunningBuild);
@@ -232,7 +232,7 @@ public class SlackNotificationListenerTest {
 	public void testBeforeBuildFinishSRunningBuild() throws FileNotFoundException, IOException {
 		BuildState state = new BuildState();
 		state.enable(BuildStateEnum.BEFORE_BUILD_FINISHED);
-		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", "master", true, state, true, true, new HashSet<String>(), true, true);
+		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", null, true, state, true, true, new HashSet<String>(), true, true);
 		when(buildHistory.getEntriesBefore(sRunningBuild, false)).thenReturn(finishedSuccessfulBuilds);
 		
 		whl.beforeBuildFinish(sRunningBuild);

--- a/tcslackbuildnotifier-core/src/test/java/slacknotifications/teamcity/SlackNotificationListenerTest.java
+++ b/tcslackbuildnotifier-core/src/test/java/slacknotifications/teamcity/SlackNotificationListenerTest.java
@@ -141,7 +141,7 @@ public class SlackNotificationListenerTest {
 	    BuildState buildState = new BuildState();
 	    SlackNotificationMainSettings mainSettings = new SlackNotificationMainSettings(sBuildServer, serverPaths);
 	    mainSettings.readFrom(getFullConfigElement());
-	    SlackNotificationConfig config = new SlackNotificationConfig("", "#general", "teamName", true, buildState, true, true, null, true, true);
+	    SlackNotificationConfig config = new SlackNotificationConfig("", "#general", "teamName", "master", true, buildState, true, true, null, true, true);
 	    SlackNotificationListener whl = new SlackNotificationListener(sBuildServer, settings, mainSettings, manager, factory);
 	    
 	    whl.getFromConfig(slackNotificationImpl, config);
@@ -173,7 +173,7 @@ public class SlackNotificationListenerTest {
 	@Test
 	public void testBuildStartedSRunningBuild() throws FileNotFoundException, IOException {
 		BuildState state = new BuildState().setAllEnabled();
-		projSettings.addNewSlackNotification("", "project1", "my-channel", "myteam", true, state, true, true, new HashSet<String>(), true, true);
+		projSettings.addNewSlackNotification("", "project1", "my-channel", "myteam", "master", true, state, true, true, new HashSet<String>(), true, true);
 		when(slacknotification.isEnabled()).thenReturn(state.allEnabled());
 		when(buildHistory.getEntriesBefore(sRunningBuild, false)).thenReturn(finishedSuccessfulBuilds);
 		
@@ -184,7 +184,7 @@ public class SlackNotificationListenerTest {
 	@Test
 	public void testBuildFinishedSRunningBuild() throws FileNotFoundException, IOException {
 		BuildState state = new BuildState().setAllEnabled();
-		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", true, state , true, true, new HashSet<String>(), true, true);
+		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", "master", true, state , true, true, new HashSet<String>(), true, true);
 		when(slacknotification.isEnabled()).thenReturn(state.allEnabled());
 		when(buildHistory.getEntriesBefore(sRunningBuild, false)).thenReturn(finishedSuccessfulBuilds);
 		
@@ -198,7 +198,7 @@ public class SlackNotificationListenerTest {
 		state.enable(BuildStateEnum.BUILD_FIXED);
 		state.enable(BuildStateEnum.BUILD_FINISHED);
 		state.enable(BuildStateEnum.BUILD_SUCCESSFUL);
-		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", true, state, true, true, new HashSet<String>(), true, true);
+		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", "master", true, state, true, true, new HashSet<String>(), true, true);
 		when(slacknotification.isEnabled()).thenReturn(state.enabled(BuildStateEnum.BUILD_FIXED));
 		when(buildHistory.getEntriesBefore(sRunningBuild, false)).thenReturn(finishedFailedBuilds);
 		
@@ -210,7 +210,7 @@ public class SlackNotificationListenerTest {
 	public void testBuildFinishedSRunningBuildSuccessAfterSuccess() throws FileNotFoundException, IOException {
 		BuildState state = new BuildState();
 		state.enable(BuildStateEnum.BUILD_FIXED);
-		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", true, state, true, true, new HashSet<String>(), true, true);
+		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", "master", true, state, true, true, new HashSet<String>(), true, true);
 		when(slacknotification.isEnabled()).thenReturn(state.enabled(BuildStateEnum.BUILD_FIXED));
 		when(buildHistory.getEntriesBefore(sRunningBuild, false)).thenReturn(finishedSuccessfulBuilds);
 		
@@ -221,7 +221,7 @@ public class SlackNotificationListenerTest {
 	@Test
 	public void testBuildInterruptedSRunningBuild() throws FileNotFoundException, IOException {
 		BuildState state = new BuildState().setAllEnabled();
-		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", true, state, true, true, new HashSet<String>(), true, true);
+		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", "master", true, state, true, true, new HashSet<String>(), true, true);
 		when(buildHistory.getEntriesBefore(sRunningBuild, false)).thenReturn(finishedSuccessfulBuilds);
 		
 		whl.buildInterrupted(sRunningBuild);
@@ -232,7 +232,7 @@ public class SlackNotificationListenerTest {
 	public void testBeforeBuildFinishSRunningBuild() throws FileNotFoundException, IOException {
 		BuildState state = new BuildState();
 		state.enable(BuildStateEnum.BEFORE_BUILD_FINISHED);
-		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", true, state, true, true, new HashSet<String>(), true, true);
+		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", "master", true, state, true, true, new HashSet<String>(), true, true);
 		when(buildHistory.getEntriesBefore(sRunningBuild, false)).thenReturn(finishedSuccessfulBuilds);
 		
 		whl.beforeBuildFinish(sRunningBuild);

--- a/tcslackbuildnotifier-core/src/test/java/slacknotifications/teamcity/settings/SlackNotificationMainSettingsTest.java
+++ b/tcslackbuildnotifier-core/src/test/java/slacknotifications/teamcity/settings/SlackNotificationMainSettingsTest.java
@@ -50,9 +50,9 @@ public class SlackNotificationMainSettingsTest {
         ServerPaths serverPaths = mock(ServerPaths.class);
         when(serverPaths.getConfigDir()).thenReturn(expectedConfigDirectory);
 
-		SlackNotificationMainSettings whms = new SlackNotificationMainSettings(server, serverPaths);
-		whms.register();
-		whms.readFrom(getFullConfigElement());
+        SlackNotificationMainSettings whms = new SlackNotificationMainSettings(server, serverPaths);
+        whms.register();
+        whms.readFrom(getFullConfigElement());
 		String proxy = whms.getProxy();
 		SlackNotificationProxyConfig whpc = whms.getProxyConfig();
 		assertTrue(proxy.equals(this.proxyHost));

--- a/tcslackbuildnotifier-core/src/test/java/slacknotifications/teamcity/settings/SlackNotificationProjectSettingsTest.java
+++ b/tcslackbuildnotifier-core/src/test/java/slacknotifications/teamcity/settings/SlackNotificationProjectSettingsTest.java
@@ -5,7 +5,13 @@ import jetbrains.buildServer.serverSide.settings.ProjectSettingsManager;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import slacknotifications.teamcity.BuildState;
 
+import java.util.HashSet;
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 public class SlackNotificationProjectSettingsTest {
@@ -27,8 +33,17 @@ public class SlackNotificationProjectSettingsTest {
 	}
 
 	@Test
-	public void TestSettings(){
-
+	public void filterBranchName_CanBeSet(){
+		SlackNotificationProjectSettingsFactory psf = new SlackNotificationProjectSettingsFactory(psm);
+		SlackNotificationProjectSettings settings = psf.createProjectSettings("project1");
+		BuildState state = new BuildState().setAllEnabled();
+		settings.addNewSlackNotification("1", "1", "#general", "Steve",
+				"master", false, state, false, false,
+				new HashSet<String>(), false, false);
+		List<SlackNotificationConfig> listOfConfigs = settings.getSlackNotificationsConfigs();
+		for (SlackNotificationConfig config : listOfConfigs) {
+			assertTrue(config.getFilterBranchName() == "master");
+		}
 	}
-	
+
 }

--- a/tcslackbuildnotifier-core/src/test/resources/main-config-empty-defaults.xml
+++ b/tcslackbuildnotifier-core/src/test/resources/main-config-empty-defaults.xml
@@ -5,7 +5,8 @@
           teamName="myteam"
           token="thisismytoken"
           iconurl="http://www.myicon.com/icon.gif"
-          botname="Team City">
+          botname="Team City"
+    filterBranchName="master">
     <proxy host="myproxy.mycompany.com" port="8080"/>
     <info url="http://intranet.mycompany.com/docs/UsingSlackNotifications" text="Using SlackNotifications in myCompany Inc." />
   </slacknotifications>

--- a/tcslackbuildnotifier-core/src/test/resources/main-config-full.xml
+++ b/tcslackbuildnotifier-core/src/test/resources/main-config-full.xml
@@ -11,7 +11,8 @@
           showCommits="false"
           showCommitters="false"
           maxCommitsToDisplay="15"
-          showFailureReason="true">
+          showFailureReason="true"
+          filterBranchName="master">
     <proxy host="myproxy.mycompany.com" port="8080" username="some-username" password="some-password" />
     <info url="http://intranet.mycompany.com/docs/UsingSlackNotifications" text="Using SlackNotifications in myCompany Inc." />
   </slacknotifications>

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotificationAjaxEditPageController.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotificationAjaxEditPageController.java
@@ -214,8 +214,8 @@ public class SlackNotificationAjaxEditPageController extends BaseController {
 			    						}
 		    						
 			    						if ("new".equals(request.getParameter(SLACK_NOTIFICATION_ID))){
-			    							projSettings.addNewSlackNotification(myProject.getProjectId(), request.getParameter("token"), request.getParameter(CHANNEL), request.getParameter("team"), enabled,
-													states, buildTypeAll, buildTypeSubProjects, buildTypes, mentionChannelEnabled, mentionSlackUserEnabled);
+			    							projSettings.addNewSlackNotification(myProject.getProjectId(), request.getParameter("token"), request.getParameter(CHANNEL), request.getParameter("team"), request.getParameter("filterBranchName"),
+													enabled, states, buildTypeAll, buildTypeSubProjects, buildTypes, mentionChannelEnabled, mentionSlackUserEnabled);
 			    							if(projSettings.updateSuccessful()){
 			    								myProject.persist();
 			    	    						params.put(MESSAGES, ERRORS_TAG);
@@ -224,9 +224,9 @@ public class SlackNotificationAjaxEditPageController extends BaseController {
 			    							}
 			    						} else {
 			    							projSettings.updateSlackNotification(myProject.getProjectId(), request.getParameter("token"),
-                                                    request.getParameter(SLACK_NOTIFICATION_ID), request.getParameter(CHANNEL), enabled,
-													states, buildTypeAll, buildTypeSubProjects, buildTypes, mentionChannelEnabled,
-													mentionSlackUserEnabled, content);
+                                                    request.getParameter(SLACK_NOTIFICATION_ID), request.getParameter(CHANNEL),
+													request.getParameter("filterBranchName"), enabled, states, buildTypeAll,
+													buildTypeSubProjects, buildTypes, mentionChannelEnabled, mentionSlackUserEnabled, content);
 			    							if(projSettings.updateSuccessful()){
 			    								myProject.persist();
 			    	    						params.put(MESSAGES, ERRORS_TAG);

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotifierAdminPage.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotifierAdminPage.java
@@ -64,6 +64,7 @@ public class SlackNotifierAdminPage extends AdminPage {
         model.put("botName", this.slackMainSettings.getBotName());
         model.put("iconUrl", this.slackMainSettings.getIconUrl());
         model.put("defaultChannel", this.slackMainSettings.getDefaultChannel());
+        model.put("branchName", this.slackMainSettings.getBranchName());
         model.put("maxCommitsToDisplay", this.slackMainSettings.getMaxCommitsToDisplay());
         model.put("showBuildAgent", this.slackMainSettings.getShowBuildAgent());
         model.put("showCommits", this.slackMainSettings.getShowCommits());

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotifierAdminPage.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotifierAdminPage.java
@@ -64,7 +64,6 @@ public class SlackNotifierAdminPage extends AdminPage {
         model.put("botName", this.slackMainSettings.getBotName());
         model.put("iconUrl", this.slackMainSettings.getIconUrl());
         model.put("defaultChannel", this.slackMainSettings.getDefaultChannel());
-        model.put("branchName", this.slackMainSettings.getBranchName());
         model.put("maxCommitsToDisplay", this.slackMainSettings.getMaxCommitsToDisplay());
         model.put("showBuildAgent", this.slackMainSettings.getShowBuildAgent());
         model.put("showCommits", this.slackMainSettings.getShowCommits());

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotifierSettingsController.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotifierSettingsController.java
@@ -56,6 +56,7 @@ public class SlackNotifierSettingsController extends BaseController {
     private SlackNotificationMainConfig config;
     private SlackNotificationPayloadManager payloadManager;
     private PluginDescriptor descriptor;
+    private String branchName;
 
     public SlackNotifierSettingsController(@NotNull SBuildServer server,
                                            @NotNull ServerPaths serverPaths,
@@ -111,6 +112,7 @@ public class SlackNotifierSettingsController extends BaseController {
         showBuildAgent = request.getParameter("showBuildAgent");
         showCommits = request.getParameter("showCommits");
         showCommitters = request.getParameter("showCommitters");
+        branchName = request.getParameter("branchName");
         showElapsedBuildTime = request.getParameter("showElapsedBuildTime");
         showFailureReason = request.getParameter("showFailureReason");
         proxyHost = request.getParameter("proxyHost");
@@ -128,7 +130,7 @@ public class SlackNotifierSettingsController extends BaseController {
         SlackNotification notification = createMockNotification(teamName, defaultChannel, botName,
                 token, iconUrl, Integer.parseInt(maxCommitsToDisplay),
                 Boolean.parseBoolean(showElapsedBuildTime), Boolean.parseBoolean(showBuildAgent),
-                Boolean.parseBoolean(showCommits), Boolean.parseBoolean(showCommitters), Boolean.parseBoolean(showFailureReason),
+                Boolean.parseBoolean(showCommits), Boolean.parseBoolean(showCommitters), branchName, Boolean.parseBoolean(showFailureReason),
                 proxyHost, proxyPort, proxyUser, proxyPassword);
 
 
@@ -168,7 +170,7 @@ public class SlackNotifierSettingsController extends BaseController {
     public SlackNotification createMockNotification(String teamName, String defaultChannel, String botName,
                                                     String token, String iconUrl, Integer maxCommitsToDisplay,
                                                     Boolean showElapsedBuildTime, Boolean showBuildAgent, Boolean showCommits,
-                                                    Boolean showCommitters, Boolean showFailureReason, String proxyHost,
+                                                    Boolean showCommitters, String branchName, Boolean showFailureReason, String proxyHost,
                                                     String proxyPort, String proxyUser, String proxyPassword) {
         SlackNotification notification = new SlackNotificationImpl(defaultChannel);
         notification.setTeamName(teamName);
@@ -180,6 +182,7 @@ public class SlackNotifierSettingsController extends BaseController {
         notification.setShowBuildAgent(showBuildAgent);
         notification.setShowCommits(showCommits);
         notification.setShowCommitters(showCommitters);
+        notification.setBranchName(branchName);
         notification.setShowFailureReason(showFailureReason);
 
         if(proxyHost != null && !StringUtil.isEmpty(proxyHost)){
@@ -245,6 +248,7 @@ public class SlackNotifierSettingsController extends BaseController {
         this.config.getContent().setShowBuildAgent(Boolean.parseBoolean(showBuildAgent));
         this.config.getContent().setShowCommits(Boolean.parseBoolean(showCommits));
         this.config.getContent().setShowCommitters(Boolean.parseBoolean(showCommitters));
+        this.config.getContent().setBranchName(branchName);
         this.config.getContent().setShowElapsedBuildTime((Boolean.parseBoolean(showElapsedBuildTime)));
         this.config.getContent().setShowFailureReason((Boolean.parseBoolean(showFailureReason)));
 

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotifierSettingsController.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotifierSettingsController.java
@@ -56,7 +56,7 @@ public class SlackNotifierSettingsController extends BaseController {
     private SlackNotificationMainConfig config;
     private SlackNotificationPayloadManager payloadManager;
     private PluginDescriptor descriptor;
-    private String branchName;
+    private String filterBranchName;
 
     public SlackNotifierSettingsController(@NotNull SBuildServer server,
                                            @NotNull ServerPaths serverPaths,
@@ -112,7 +112,7 @@ public class SlackNotifierSettingsController extends BaseController {
         showBuildAgent = request.getParameter("showBuildAgent");
         showCommits = request.getParameter("showCommits");
         showCommitters = request.getParameter("showCommitters");
-        branchName = request.getParameter("branchName");
+        filterBranchName = request.getParameter("filterBranchName");
         showElapsedBuildTime = request.getParameter("showElapsedBuildTime");
         showFailureReason = request.getParameter("showFailureReason");
         proxyHost = request.getParameter("proxyHost");
@@ -130,7 +130,7 @@ public class SlackNotifierSettingsController extends BaseController {
         SlackNotification notification = createMockNotification(teamName, defaultChannel, botName,
                 token, iconUrl, Integer.parseInt(maxCommitsToDisplay),
                 Boolean.parseBoolean(showElapsedBuildTime), Boolean.parseBoolean(showBuildAgent),
-                Boolean.parseBoolean(showCommits), Boolean.parseBoolean(showCommitters), branchName, Boolean.parseBoolean(showFailureReason),
+                Boolean.parseBoolean(showCommits), Boolean.parseBoolean(showCommitters), filterBranchName, Boolean.parseBoolean(showFailureReason),
                 proxyHost, proxyPort, proxyUser, proxyPassword);
 
 
@@ -182,7 +182,7 @@ public class SlackNotifierSettingsController extends BaseController {
         notification.setShowBuildAgent(showBuildAgent);
         notification.setShowCommits(showCommits);
         notification.setShowCommitters(showCommitters);
-        notification.setBranchName(branchName);
+        notification.setFilterBranchName(branchName);
         notification.setShowFailureReason(showFailureReason);
 
         if(proxyHost != null && !StringUtil.isEmpty(proxyHost)){
@@ -248,16 +248,14 @@ public class SlackNotifierSettingsController extends BaseController {
         this.config.getContent().setShowBuildAgent(Boolean.parseBoolean(showBuildAgent));
         this.config.getContent().setShowCommits(Boolean.parseBoolean(showCommits));
         this.config.getContent().setShowCommitters(Boolean.parseBoolean(showCommitters));
-        this.config.getContent().setBranchName(branchName);
+        this.config.getContent().setFilterBranchName(filterBranchName);
         this.config.getContent().setShowElapsedBuildTime((Boolean.parseBoolean(showElapsedBuildTime)));
         this.config.getContent().setShowFailureReason((Boolean.parseBoolean(showFailureReason)));
-
 
         this.config.setProxyHost(proxyHost);
         this.config.setProxyPort(isNullOrEmpty(proxyPort) ? null : Integer.parseInt(proxyPort));
         this.config.setProxyUsername(proxyUser);
         this.config.setProxyPassword(proxyPassword);
-
 
         this.config.save();
 

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotifierSettingsController.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotifierSettingsController.java
@@ -21,6 +21,9 @@ import slacknotifications.teamcity.settings.SlackNotificationMainConfig;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -248,7 +251,7 @@ public class SlackNotifierSettingsController extends BaseController {
         this.config.getContent().setShowBuildAgent(Boolean.parseBoolean(showBuildAgent));
         this.config.getContent().setShowCommits(Boolean.parseBoolean(showCommits));
         this.config.getContent().setShowCommitters(Boolean.parseBoolean(showCommitters));
-        this.config.getContent().setFilterBranchName(filterBranchName);
+        this.config.setFilterBranchName(filterBranchName);
         this.config.getContent().setShowElapsedBuildTime((Boolean.parseBoolean(showElapsedBuildTime)));
         this.config.getContent().setShowFailureReason((Boolean.parseBoolean(showFailureReason)));
 

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/bean/ProjectSlackNotificationsBean.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/bean/ProjectSlackNotificationsBean.java
@@ -23,7 +23,7 @@ public class ProjectSlackNotificationsBean {
 		bean.slackNotificationList = new LinkedHashMap<String, SlacknotificationConfigAndBuildTypeListHolder>();
 
 		/* Create a "new" config with blank stuff so that clicking the "new" button has a bunch of defaults to load in */
-		SlackNotificationConfig newBlankConfig = new SlackNotificationConfig("", "", "", true, new BuildState().setAllEnabled(), true, true, null, true, true);
+		SlackNotificationConfig newBlankConfig = new SlackNotificationConfig("", "", "", "", true, new BuildState().setAllEnabled(), true, true, null, true, true);
 		newBlankConfig.setUniqueKey("new");
 		/* And add it to the list */
 		addSlackNotificationConfigHolder(bean, projectBuildTypes, newBlankConfig, mainSettings);
@@ -47,7 +47,7 @@ public class ProjectSlackNotificationsBean {
 		bean.slackNotificationList = new LinkedHashMap<String, SlacknotificationConfigAndBuildTypeListHolder>();
 		
 		/* Create a "new" config with blank stuff so that clicking the "new" button has a bunch of defaults to load in */
-		SlackNotificationConfig newBlankConfig = new SlackNotificationConfig("", "", "", true, new BuildState().setAllEnabled(), false, false, enabledBuildTypes, true, true);
+		SlackNotificationConfig newBlankConfig = new SlackNotificationConfig("", "", "", "", true, new BuildState().setAllEnabled(), false, false, enabledBuildTypes, true, true);
 		newBlankConfig.setUniqueKey("new");
 		/* And add it to the list */
 		addSlackNotificationConfigHolder(bean, projectBuildTypes, newBlankConfig, mainSettings);

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/bean/SlacknotificationConfigAndBuildTypeListHolder.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/bean/SlacknotificationConfigAndBuildTypeListHolder.java
@@ -36,6 +36,7 @@ public class SlacknotificationConfigAndBuildTypeListHolder {
     private boolean showCommitters;
     private int maxCommitsToDisplay;
     private boolean showFailureReason;
+    private String filterBranchName;
     private String botName;
     private String iconUrl;
 
@@ -60,6 +61,7 @@ public class SlacknotificationConfigAndBuildTypeListHolder {
         showCommits = valueOrFallback(config.getContent().getShowCommits(), valueOrFallback(mainSettings.getShowCommits(), SlackNotificationContentConfig.DEFAULT_SHOW_COMMITS));
         showCommitters = valueOrFallback(config.getContent().getShowCommitters(), valueOrFallback(mainSettings.getShowCommitters(), SlackNotificationContentConfig.DEFAULT_SHOW_COMMITTERS));
         showFailureReason = valueOrFallback(config.getContent().getShowFailureReason(), valueOrFallback(mainSettings.getShowFailureReason(), SlackNotificationContentConfig.DEFAULT_SHOW_FAILURE_REASON));
+        filterBranchName = valueOrFallback(config.getFilterBranchName(), valueOrFallback(mainSettings.getFilterBranchName(),SlackNotificationContentConfig.DEFAULT_FILTER_BRANCH_NAME));
         botName = valueOrFallback(config.getContent().getBotName(), SlackNotificationMainConfig.DEFAULT_BOTNAME);
         iconUrl = valueOrFallback(config.getContent().getIconUrl(), SlackNotificationMainConfig.DEFAULT_ICONURL);
 	}

--- a/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/index.jsp
+++ b/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/index.jsp
@@ -123,6 +123,7 @@
 					jQuerySlacknotification('#slackNotificationId').val(slacknotification.uniqueKey);
 					jQuerySlacknotification('#slackNotificationToken').val(slacknotification.token);
 					jQuerySlacknotification('#slackNotificationChannel').val(slacknotification.channel);
+					jQuerySlacknotification('#filterBranchName').val(slacknotification.filterBranchName);
 				    jQuerySlacknotification('#slackNotificationsEnabled').attr('checked', slacknotification.enabled);
 				    jQuerySlacknotification.each(slacknotification.states, function(name, value){
 				    	jQuerySlacknotification('#' + value.buildStateName).attr('checked', value.enabled);

--- a/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/slackAdminSettings.jsp
+++ b/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/slackAdminSettings.jsp
@@ -104,15 +104,6 @@
                 </tr>
                 <tr>
                     <th>
-                        <label for="branchName">Only for specific branch: </label>
-                    </th>
-                    <td>
-                       <forms:textField name="branchName" value="${branchName}" style="width: 70px;" />
-                        <span style="color: #888; font-size: 90%;">When specified, the name of the branch to send notifications</span>
-                    </td>
-                </tr>
-                <tr>
-                    <th>
                         <label for="showCommitters">Show committers: </label>
                     </th>
                     <td>

--- a/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/slackAdminSettings.jsp
+++ b/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/slackAdminSettings.jsp
@@ -104,6 +104,15 @@
                 </tr>
                 <tr>
                     <th>
+                        <label for="branchName">Only for specific branch: </label>
+                    </th>
+                    <td>
+                       <forms:textField name="branchName" value="${branchName}" style="width: 70px;" />
+                        <span style="color: #888; font-size: 90%;">When specified, the name of the branch to send notifications</span>
+                    </td>
+                </tr>
+                <tr>
+                    <th>
                         <label for="showCommitters">Show committers: </label>
                     </th>
                     <td>

--- a/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/slackNotificationInclude.jsp
+++ b/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/slackNotificationInclude.jsp
@@ -96,7 +96,11 @@
                                                 </tr>
                                                 <tr style="border:none;">
                                                     <td>Branch Name:</td>
-                                                    <td colspan=2><input id="branchName" name="branchName" type=text maxlength=512 style="margin: 0pt; padding: 0pt; width: 36em;" watermark="master"/></td>
+                                                    <td colspan=2><input id="filterBranchName" name="filterBranchName" type=text maxlength=512 style="margin: 0pt; padding: 0pt; width: 36em;" watermark="master"/></td>
+                                                </tr>
+												<tr style="border:none">
+                                                  <td></td>
+                                                  <td colspan="2"><span class="smallNote" style="margin-left:0px;">Only notify for builds on this branch.</span></td>
                                                 </tr>
 												<tr style="border:none;">
 													<td><label for="slackNotificationsEnabled">Enabled:</label></td>

--- a/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/slackNotificationInclude.jsp
+++ b/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/slackNotificationInclude.jsp
@@ -100,7 +100,7 @@
                                                 </tr>
 												<tr style="border:none">
                                                   <td></td>
-                                                  <td colspan="2"><span class="smallNote" style="margin-left:0px;">Only notify for builds on this branch.</span></td>
+                                                  <td colspan="2"><span class="smallNote" style="margin-left:0px;">Only notify for builds on this branch. Note that if you want to notify on the default branch, use the magic value &lt;default&gt;.</span></td>
                                                 </tr>
 												<tr style="border:none;">
 													<td><label for="slackNotificationsEnabled">Enabled:</label></td>

--- a/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/slackNotificationInclude.jsp
+++ b/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/slackNotificationInclude.jsp
@@ -94,6 +94,10 @@
                                                   <td></td>
                                                   <td colspan="2"><span class="smallNote" style="margin-left:0px;">Make sure you include the leading # if you are posting to a channel e.g. #my-channel</span></td>
                                                 </tr>
+                                                <tr style="border:none;">
+                                                    <td>Branch Name:</td>
+                                                    <td colspan=2><input id="branchName" name="branchName" type=text maxlength=512 style="margin: 0pt; padding: 0pt; width: 36em;" watermark="master"/></td>
+                                                </tr>
 												<tr style="border:none;">
 													<td><label for="slackNotificationsEnabled">Enabled:</label></td>
 													<td style="padding-left:3px;" colspan=2><input id="slackNotificationsEnabled" type=checkbox name="slackNotificationsEnabled"/></td>

--- a/tcslackbuildnotifier-web-ui/src/test/java/slacknotifications/teamcity/extension/SlackNotificationSettingsControllerTest.java
+++ b/tcslackbuildnotifier-web-ui/src/test/java/slacknotifications/teamcity/extension/SlackNotificationSettingsControllerTest.java
@@ -36,7 +36,7 @@ public class SlackNotificationSettingsControllerTest {
                 config, payloadManager, pluginDescriptor);
 
         SlackNotification notification = controller.createMockNotification("the team", "#general", "The Bot", "tokenthingy",
-                SlackNotificationMainConfig.DEFAULT_ICONURL, 5, true, true, true, true, true, null, null, null, null);
+                SlackNotificationMainConfig.DEFAULT_ICONURL, 5, true, true, true, true, "master", true, null, null, null, null);
 
         assertNotNull(notification);
         assertEquals("the team", notification.getTeamName());


### PR DESCRIPTION
Allows failed build notifications to be sent only for build failures on a specified branch (e.g. `master`).

Can be configured per-notification in the config UI.